### PR TITLE
Handle frame drop

### DIFF
--- a/cpp/kiss_icp/core/Deskew.cpp
+++ b/cpp/kiss_icp/core/Deskew.cpp
@@ -40,7 +40,7 @@ std::vector<Eigen::Vector3d> DeSkewScan(const std::vector<Eigen::Vector3d> &fram
                                         const Sophus::SE3d &finish_pose,
                                         int prev_frame_delta) {
     if (prev_frame_delta <= 0) {
-	throw std::runtime_error("Math error. prev_frame_delta has to be greater than zero.\n");
+	throw std::runtime_error("Math error. prev_frame_delta has to be greater than zero.");
     }
     const auto delta_pose = (start_pose.inverse() * finish_pose).log() / prev_frame_delta;
     std::vector<Eigen::Vector3d> corrected_frame(frame.size());

--- a/cpp/kiss_icp/core/Deskew.cpp
+++ b/cpp/kiss_icp/core/Deskew.cpp
@@ -38,7 +38,10 @@ std::vector<Eigen::Vector3d> DeSkewScan(const std::vector<Eigen::Vector3d> &fram
                                         const std::vector<double> &timestamps,
                                         const Sophus::SE3d &start_pose,
                                         const Sophus::SE3d &finish_pose,
-					int prev_frame_delta) {
+                                        int prev_frame_delta) {
+    if (prev_frame_delta <= 0) {
+	throw std::runtime_error("Math error. prev_frame_delta has to be greater than zero.\n");
+    }
     const auto delta_pose = (start_pose.inverse() * finish_pose).log() / prev_frame_delta;
     std::vector<Eigen::Vector3d> corrected_frame(frame.size());
     tbb::parallel_for(size_t(0), frame.size(), [&](size_t i) {

--- a/cpp/kiss_icp/core/Deskew.cpp
+++ b/cpp/kiss_icp/core/Deskew.cpp
@@ -37,8 +37,9 @@ namespace kiss_icp {
 std::vector<Eigen::Vector3d> DeSkewScan(const std::vector<Eigen::Vector3d> &frame,
                                         const std::vector<double> &timestamps,
                                         const Sophus::SE3d &start_pose,
-                                        const Sophus::SE3d &finish_pose) {
-    const auto delta_pose = (start_pose.inverse() * finish_pose).log();
+                                        const Sophus::SE3d &finish_pose,
+					int prev_ratio) {
+    const auto delta_pose = (start_pose.inverse() * finish_pose).log() / prev_ratio;
     std::vector<Eigen::Vector3d> corrected_frame(frame.size());
     tbb::parallel_for(size_t(0), frame.size(), [&](size_t i) {
         const auto motion = Sophus::SE3d::exp((timestamps[i] - mid_pose_timestamp) * delta_pose);

--- a/cpp/kiss_icp/core/Deskew.cpp
+++ b/cpp/kiss_icp/core/Deskew.cpp
@@ -38,8 +38,8 @@ std::vector<Eigen::Vector3d> DeSkewScan(const std::vector<Eigen::Vector3d> &fram
                                         const std::vector<double> &timestamps,
                                         const Sophus::SE3d &start_pose,
                                         const Sophus::SE3d &finish_pose,
-					int prev_ratio) {
-    const auto delta_pose = (start_pose.inverse() * finish_pose).log() / prev_ratio;
+					int prev_frame_delta) {
+    const auto delta_pose = (start_pose.inverse() * finish_pose).log() / prev_frame_delta;
     std::vector<Eigen::Vector3d> corrected_frame(frame.size());
     tbb::parallel_for(size_t(0), frame.size(), [&](size_t i) {
         const auto motion = Sophus::SE3d::exp((timestamps[i] - mid_pose_timestamp) * delta_pose);

--- a/cpp/kiss_icp/core/Deskew.hpp
+++ b/cpp/kiss_icp/core/Deskew.hpp
@@ -32,6 +32,6 @@ namespace kiss_icp {
 std::vector<Eigen::Vector3d> DeSkewScan(const std::vector<Eigen::Vector3d> &frame,
                                         const std::vector<double> &timestamps,
                                         const Sophus::SE3d &start_pose,
-                                        const Sophus::SE3d &finish_pose, int prev_ratio=1);
+                                        const Sophus::SE3d &finish_pose, int prev_frame_delta=1);
 
 }  // namespace kiss_icp

--- a/cpp/kiss_icp/core/Deskew.hpp
+++ b/cpp/kiss_icp/core/Deskew.hpp
@@ -32,6 +32,6 @@ namespace kiss_icp {
 std::vector<Eigen::Vector3d> DeSkewScan(const std::vector<Eigen::Vector3d> &frame,
                                         const std::vector<double> &timestamps,
                                         const Sophus::SE3d &start_pose,
-                                        const Sophus::SE3d &finish_pose);
+                                        const Sophus::SE3d &finish_pose, int prev_ratio=1);
 
 }  // namespace kiss_icp

--- a/python/kiss_icp/deskew.py
+++ b/python/kiss_icp/deskew.py
@@ -36,7 +36,7 @@ class StubCompensator:
 
 
 class MotionCompensator:
-    def deskew_scan(self, frame, poses, timestamps):
+    def deskew_scan(self, frame, poses, timestamps, prev_frame_delta = 1):
         if len(poses) < 2:
             return frame
         deskew_frame = kiss_icp_pybind._deskew_scan(
@@ -44,5 +44,6 @@ class MotionCompensator:
             timestamps=timestamps,
             start_pose=poses[-2],
             finish_pose=poses[-1],
+            prev_frame_delta=prev_frame_delta,
         )
         return np.asarray(deskew_frame)

--- a/python/kiss_icp/pybind/kiss_icp_pybind.cpp
+++ b/python/kiss_icp/pybind/kiss_icp_pybind.cpp
@@ -103,12 +103,12 @@ PYBIND11_MODULE(kiss_icp_pybind, m) {
     m.def(
         "_deskew_scan",
         [](const std::vector<Eigen::Vector3d> &frame, const std::vector<double> &timestamps,
-           const Eigen::Matrix4d &T_start, const Eigen::Matrix4d &T_finish) {
+           const Eigen::Matrix4d &T_start, const Eigen::Matrix4d &T_finish, int prev_frame_delta=1) {
             Sophus::SE3d start_pose(T_start);
             Sophus::SE3d finish_pose(T_finish);
-            return DeSkewScan(frame, timestamps, start_pose, finish_pose);
+            return DeSkewScan(frame, timestamps, start_pose, finish_pose, prev_frame_delta);
         },
-        "frame"_a, "timestamps"_a, "start_pose"_a, "finish_pose"_a);
+        "frame"_a, "timestamps"_a, "start_pose"_a, "finish_pose"_a, "prev_frame_delta"_a);
 
     // prerpocessing modules
     m.def("_voxel_down_sample", &VoxelDownsample, "frame"_a, "voxel_size"_a);

--- a/python/kiss_icp/pybind/kiss_icp_pybind.cpp
+++ b/python/kiss_icp/pybind/kiss_icp_pybind.cpp
@@ -103,12 +103,12 @@ PYBIND11_MODULE(kiss_icp_pybind, m) {
     m.def(
         "_deskew_scan",
         [](const std::vector<Eigen::Vector3d> &frame, const std::vector<double> &timestamps,
-           const Eigen::Matrix4d &T_start, const Eigen::Matrix4d &T_finish, int prev_frame_delta=1) {
+           const Eigen::Matrix4d &T_start, const Eigen::Matrix4d &T_finish, int prev_frame_delta) {
             Sophus::SE3d start_pose(T_start);
             Sophus::SE3d finish_pose(T_finish);
             return DeSkewScan(frame, timestamps, start_pose, finish_pose, prev_frame_delta);
         },
-        "frame"_a, "timestamps"_a, "start_pose"_a, "finish_pose"_a, "prev_frame_delta"_a);
+        "frame"_a, "timestamps"_a, "start_pose"_a, "finish_pose"_a, "prev_frame_delta"_a = 1);
 
     // prerpocessing modules
     m.def("_voxel_down_sample", &VoxelDownsample, "frame"_a, "voxel_size"_a);


### PR DESCRIPTION
Handle frame drop in fork kiss icp repo.

The only API change is in `kiss_icp.py`. Function changed from `def register_frame(self, frame, timestamps)` to `def register_frame(self, frame, timestamps, frame_delta=1)`